### PR TITLE
Allow disabling of the pid in the source submission

### DIFF
--- a/lib/librato/rails.rb
+++ b/lib/librato/rails.rb
@@ -19,7 +19,7 @@ module Librato
 
   module Rails
     extend SingleForwardable
-    CONFIG_SETTABLE = %w{user token flush_interval prefix source}
+    CONFIG_SETTABLE = %w{user token flush_interval prefix source use_pid}
     FORKING_SERVERS = [:unicorn, :passenger]
 
     mattr_accessor :config_file
@@ -30,9 +30,11 @@ module Librato
     mattr_accessor :token
     mattr_accessor :flush_interval
     mattr_accessor :prefix
+    mattr_accessor :use_pid
 
     # config defaults
     self.flush_interval = 60 # seconds
+    self.use_pid = true
 
     def_delegators :counters, :increment
     def_delegators :aggregate, :measure, :timing
@@ -114,7 +116,11 @@ module Librato
 
       # source including process pid
       def qualified_source
-        "#{source}.#{$$}"
+        if self.use_pid
+          "#{source}.#{$$}"
+        else
+          source
+        end
       end
 
       # run once during Rails startup sequence

--- a/test/fixtures/config/librato.yml
+++ b/test/fixtures/config/librato.yml
@@ -4,6 +4,7 @@ test:
   prefix: 'rails-test'
   flush_interval: 30
   source: 'custom-1'
+  use_pid: false
   
 production:
   user: 'live@bar.com'

--- a/test/metrics-rails_test.rb
+++ b/test/metrics-rails_test.rb
@@ -36,4 +36,9 @@ class LibratoRailsTest < ActiveSupport::TestCase
     assert_match /\.\d{2,6}$/, Librato::Rails.qualified_source
   end
   
+  test 'qualified source does not include pid when disabled' do
+    Librato::Rails.use_pid = false
+    assert_match Librato::Rails.source, Librato::Rails.qualified_source
+    Librato::Rails.use_pid = true
+  end
 end

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -27,6 +27,7 @@ class LibratoRailsAggregatorTest < MiniTest::Unit::TestCase
       assert_equal 'rails-test', Librato::Rails.prefix
       assert_equal 30, Librato::Rails.flush_interval
       assert_equal 'custom-1', Librato::Rails.source
+      assert_equal false, Librato::Rails.use_pid
     end
   end
 


### PR DESCRIPTION
When submitting via resque workers, I am getting new PIDs each time, causing my metrics to look a little funny. To resolve this, I've added an option to disable the pid in the `qualified_source` method, so the metrics all go up as one system.

If there is a better way to do this, or a means of doing this in the Librato interface itself, I'd love to know. Thanks!
