### PR TITLE
Counters don't report a value if they aren't incremented during a period.

### DIFF
--- a/lib/librato/rails/counter_cache.rb
+++ b/lib/librato/rails/counter_cache.rb
@@ -23,7 +23,7 @@ module Librato
         counts = nil
         @lock.synchronize do
           counts = @cache.dup
-          @cache.clear
+          @cache.each_key { |key| @cache[key] = 0 }
         end
         counts.each do |key, value| 
           queue.add key => value

--- a/test/remote/rails_remote_test.rb
+++ b/test/remote/rails_remote_test.rb
@@ -43,11 +43,11 @@ class LibratoRailsRemoteTest < ActiveSupport::TestCase
       assert_equal 2, bar[source][0]['value']
     end
   
-    test 'counters should not persist through flush' do
+    test 'counters should persist through flush' do
       Librato::Rails.increment 'knightrider'
       assert_equal 1, Librato::Rails.counters['knightrider']
       Librato::Rails.flush
-      assert_equal nil, Librato::Rails.counters['knightrider']
+      assert_equal 0, Librato::Rails.counters['knightrider']
     end
   
     test 'flush sends measures/timings' do


### PR DESCRIPTION
Fixes state bug unintentionally introduced in transition of counters to gauge type behind the scenes.
