### PR TITLE
Fix checking for Passenger as current app server

### DIFF
--- a/lib/librato/rails.rb
+++ b/lib/librato/rails.rb
@@ -184,7 +184,7 @@ module Librato
       def app_server
         if defined?(::Unicorn) && defined?(::Unicorn::HttpServer) && !::Unicorn.listener_names.empty?
           :unicorn
-        elsif defined?(::IN_PHUSION_PASSENGER) || (defined?(::Passenger) && defined?(::Passenger::AbstractServer))
+        elsif defined?(::IN_PHUSION_PASSENGER) || defined?(::PhusionPassenger)
           :passenger
         elsif defined?(::Thin) && defined?(::Thin::Server)
           :thin


### PR DESCRIPTION
::PhusionPassenger is the proper constant to check for as of Passenger 3.x. With the Passenger 4 beta, AbstractServer was removed.

Phusion guys recommend only checking for ::PhusionPassenger, no need for AbstractServer (even in 3.x).
