### PR TITLE
Always check worker, it's faster.

### DIFF
--- a/benchmarks/worker_check_vs_forking_check.rb
+++ b/benchmarks/worker_check_vs_forking_check.rb
@@ -1,0 +1,17 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+require 'benchmark/ips'
+require 'librato/rails'
+
+module Librato::Rails
+  @pid == $$
+end
+
+Benchmark.ips do |x|
+  x.report('worker check') do
+    Librato::Rails.check_worker
+  end
+
+  x.report('forking server check') do
+    Librato::Rails.send(:forking_server?)
+  end
+end

--- a/lib/librato/rack/middleware.rb
+++ b/lib/librato/rack/middleware.rb
@@ -4,7 +4,7 @@ class Librato::Rack::Middleware
   end
 
   def call(env)
-    @metrics.check_worker if @metrics.send(:forking_server?)
+    @metrics.check_worker
 
     header_metrics env
 


### PR DESCRIPTION
Always check worker instead of checking server type to see if we should check.

Interestingly the pid matching check is so fast that checking server environment is actually ~4x slower. Also this may be the path for worker recovery later if needed, even on non-forking servers.
