### PR TITLE
Specify Rails version in Gemfile to avoid bundler hell

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,9 @@ source "http://rubygems.org"
 gemspec
 
 # jquery-rails is used by the dummy application
+gem 'rails', '3.2.11'
 gem 'jquery-rails'
-gem 'capybara'
+gem 'capybara', '~> 1.0'
 gem 'pry'
 #gem 'minitest'
 


### PR DESCRIPTION
Fixes this problem that I was having:

```
$ bundle
Fetching gem metadata from http://rubygems.org/.........
Fetching gem metadata from http://rubygems.org/..
Bundler could not find compatible versions for gem "rack":
  In Gemfile:
    jquery-rails (>= 0) ruby depends on
      rack (~> 1.2.1) ruby

    capybara (>= 0) ruby depends on
      rack (1.5.0)

Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    jquery-rails (>= 0) ruby depends on
      bundler (~> 1.0.0) ruby

  Current Bundler version:
    bundler (1.2.3)

This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?
Bundler could not find compatible versions for gem "rails":
  In Gemfile:
    librato-rails (>= 0) ruby depends on
      rails (>= 3.0) ruby

    jquery-rails (>= 0) ruby depends on
      rails (3.0.0.rc2)
```

Although I don't know what side effects it might have on users of older versions of Rails. I believe it shouldn't affect the gem user because I changed a development and not runtime dependency.
