### PR TITLE
flush interval of 0 will never flush

### DIFF
--- a/lib/librato/rails.rb
+++ b/lib/librato/rails.rb
@@ -128,7 +128,7 @@ module Librato
           worker = Worker.new
           worker.run_periodically(self.flush_interval) do
             flush
-          end
+          end unless self.flush_interval == 0
         end
       end
 


### PR DESCRIPTION
`Librato::Rails.flush_interval = 0` will disable flushing of the cache to the Librato service

sample initializer at `config/initializers/librato.rb`

``` ruby
Librato::Rails.flush_interval = 0
```
