### PR TITLE
By default insert middleware at beginning of stack

### DIFF
--- a/lib/librato/rails/railtie.rb
+++ b/lib/librato/rails/railtie.rb
@@ -29,7 +29,7 @@ module Librato
 
             if tracker.should_start?
               tracker.log :info, "starting up (pid #{$$}, using #{config.librato_rails.config_by})..."
-              app.middleware.use Librato::Rack, :config => config.librato_rails
+              app.middleware.insert(0, Librato::Rack, :config => config.librato_rails)
             end
           end
 


### PR DESCRIPTION
Change default placement of rack middleware to position 0 in the stack as discussed in #36.

This gives us a much more interesting delta between rack/rails metrics and allows us to capture rack-only requests, perf data, etc.
