### PR TITLE
Add request metrics broken out by http method

### DIFF
--- a/lib/librato/rails/subscribers/controller.rb
+++ b/lib/librato/rails/subscribers/controller.rb
@@ -13,6 +13,7 @@ module Librato
         format = event.payload[:format] || "all"
         format = "all" if format == "*/*"
         status = event.payload[:status]
+        http_method = event.payload[:method]
         exception = event.payload[:exception]
         # page_key = "request.#{controller}.#{action}_#{format}."
 
@@ -26,6 +27,14 @@ module Librato
           else
             r.timing 'time.db', event.payload[:db_runtime] || 0
             r.timing 'time.view', event.payload[:view_runtime] || 0
+          end
+
+          if http_method
+            http_method.downcase!
+            r.group 'method' do |m|
+              m.increment http_method
+              m.timing "#{http_method}.time", event.duration
+            end
           end
 
           unless status.blank?

--- a/test/integration/request_test.rb
+++ b/test/integration/request_test.rb
@@ -10,6 +10,7 @@ class RequestTest < ActiveSupport::IntegrationCase
     assert_equal 1, counters["rails.request.total"]
     assert_equal 1, counters["rails.request.status.200"]
     assert_equal 1, counters["rails.request.status.2xx"]
+    assert_equal 1, counters["rails.request.method.get"]
 
     visit '/status/204'
 
@@ -30,6 +31,9 @@ class RequestTest < ActiveSupport::IntegrationCase
     # status specific
     assert_equal 1, aggregate["rails.request.status.200.time"][:count]
     assert_equal 1, aggregate["rails.request.status.2xx.time"][:count]
+
+    # http method specific
+    assert_equal 1, aggregate["rails.request.method.get.time"][:count]
   end
 
   test 'track exceptions' do


### PR DESCRIPTION
Adds request metrics broken out by HTTP method:

```
rails.request.method.get
rails.request.method.get.time
rails.request.method.post
...
```
