### PR TITLE
Feature/force startup

### DIFF
--- a/lib/librato/rails/railtie.rb
+++ b/lib/librato/rails/railtie.rb
@@ -29,6 +29,7 @@ module Librato
           if tracker.should_start?
             tracker.log :info, "starting up (pid #{$$}, using #{config.librato_rails.config_by})..."
             app.middleware.insert(0, Librato::Rack, :config => config.librato_rails)
+            tracker.check_worker if config.librato_rails.autorun
           end
         end
 


### PR DESCRIPTION
Add ability to force librato-rails to start reporter up at startup instead of on first request by setting LIBRATO_AUTORUN=1.
