### PR TITLE
Travis - Ruby 2.1.0, fix Rubinius build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ rvm:
   # - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 2.1.0
   # - jruby-19mode
   # - jruby-18mode
-  # - rbx-19mode
-  # - rbx-18mode
+  # - rbx
   # - ruby-head
 
 env:

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,13 @@ gem 'mocha', :require => false
 # benchmarking
 gem 'benchmark_suite'
 
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'racc'
+  gem 'rubysl-test-unit'
+  gem 'rubinius-developer_tools'
+end
+
 # servers for testing
 # gem 'thin'
 # gem 'unicorn'


### PR DESCRIPTION
1. Added Ruby 2.1.0 to Travis CI.
2. Fixed rbx labels and added Rubinius gems to Gemfile so specs run under Rubinius
