### PR TITLE
update Ruby version support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ librato-rails
 
 `librato-rails` will report key statistics for your Rails app to [Librato](https://metrics.librato.com/) and allow you to easily track your own custom metrics. Metrics are delivered asynchronously behind the scenes so they won't affect performance of your requests.
 
-Rails versions 3.0 or greater are supported on Ruby 1.9.2 and above.
+Rails versions 3.0 or greater are supported on Ruby 1.9.3 and above.
 
 Verified combinations of Ruby/Rails are available in our [build matrix](http://travis-ci.org/librato/librato-rails).
 


### PR DESCRIPTION
According to https://github.com/librato/librato-rails/commit/f80ca4f86859300816d9200853e7aa0452be121d support for 1.9.2 was kinda dropped, at least removed from Travis, to me this means dropping support, unless I am missing some context which could be the case!