### PR TITLE
Allow instrumenting all actions automatically.

### DIFF
--- a/lib/librato/rails/helpers/controller.rb
+++ b/lib/librato/rails/helpers/controller.rb
@@ -3,14 +3,19 @@ module Librato
     module Helpers
       module Controller
 
-        # Mark a specific controller action for more detailed instrumenting
+        # Mark a specific controller action for more detailed instrumenting, or all actions if no *actions passed in
+        # Add to self.inherited if you also want to enable this in subclasses
         def instrument_action(*actions)
-          actions.each do |action|
-            Subscribers.watch_controller_action(self.to_s, action)
+          if actions.count > 0
+            actions.each do |action|
+              Subscribers.watch_controller_action(self.to_s, action)
+            end
+          else
+            Subscribers.watch_controller(self.to_s)
           end
         end
-
       end
     end
   end
 end
+

--- a/lib/librato/rails/subscribers/controller.rb
+++ b/lib/librato/rails/subscribers/controller.rb
@@ -4,6 +4,11 @@ module Librato
 
       # Controllers
 
+      def self.watch_controller(controller)
+        @watches ||= []
+        @watches << "#{controller}".freeze
+      end
+
       def self.watch_controller_action(controller, action)
         @watches ||= []
         @watches << "#{controller}##{action}".freeze
@@ -55,7 +60,7 @@ module Librato
           r.increment 'slow' if event.duration > 200.0
         end # end group
 
-        if @watches && @watches.index("#{controller}##{action}")
+        if @watches && (@watches.index("#{controller}##{action}") || @watches.index("#{controller}"))
           source = "#{controller}.#{action}.#{format}"
           collector.group 'rails.action.request' do |r|
 

--- a/test/dummy/app/controllers/instrument_all_actions_controller.rb
+++ b/test/dummy/app/controllers/instrument_all_actions_controller.rb
@@ -1,0 +1,22 @@
+class InstrumentAllActionsController < ApplicationController
+  # extend Librato::Rails::Helpers::Controller
+  # before_filter :before
+
+  instrument_action
+
+  def inst
+    Librato.timing 'internal execution' do
+      render nothing: true
+    end
+  end
+
+  def not_instrumented
+    render nothing: true
+  end
+
+  private
+
+  def before
+    sleep 1
+  end
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -18,7 +18,10 @@ Dummy::Application.routes.draw do
   get 'render/template' => 'render#template', :as => :render_template
 
   get 'instrument/inst' => 'instrument_action#inst', :as => :instrument_action
-  get 'instrument/not'  => 'instrument_action#not',  :as => :not_instrumented
+  get 'instrument/not'  => 'instrument_action#not_instrumented',  :as => :not_instrumented
+
+  get 'instrument_all/inst' => 'instrument_all_actions#inst', :as => :instrument_all_actions
+  get 'instrument_all/not'  => 'instrument_all_actions#not_instrumented',  :as => :still_instrumented
 
   # The priority is based upon order of creation:
   # first created -> highest priority.

--- a/test/integration/instrument_action_test.rb
+++ b/test/integration/instrument_action_test.rb
@@ -4,19 +4,38 @@ class InstrumentActionTest < ActiveSupport::IntegrationCase
 
   test 'instrument controller action' do
     visit instrument_action_path
+    visit not_instrumented_path
 
     # puts aggregate.instance_variable_get(:@cache).queued.inspect
     # puts counters.instance_variable_get(:@cache).inspect
 
     source = 'InstrumentActionController.inst.html'
+    source_not_instrumented = 'InstrumentActionController.not_instrumented.html'
 
     base = 'rails.action.request'
     timings = %w{time time.db time.view}
     timings.each do |t|
       assert_equal 1, aggregate.fetch("#{base}.#{t}", source: source)[:count]
+      assert_nil aggregate.fetch("#{base}.#{t}", source: source_not_instrumented)
     end
 
     assert_equal 1, counters.fetch("#{base}.total", source: source)
   end
 
+  test 'automatically instrument all actions' do
+    visit instrument_all_actions_path
+    visit still_instrumented_path
+
+    source = 'InstrumentAllActionsController.inst.html'
+    source_not_instrumented = 'InstrumentAllActionsController.not_instrumented.html'
+
+    base = 'rails.action.request'
+    timings = %w{time time.db time.view}
+    timings.each do |t|
+      assert_equal 1, aggregate.fetch("#{base}.#{t}", source: source)[:count]
+      assert_equal 1, aggregate.fetch("#{base}.#{t}", source: source_not_instrumented)[:count]
+    end
+
+    assert_equal 1, counters.fetch("#{base}.total", source: source)
+  end
 end


### PR DESCRIPTION
Adding a new option "instrument_all_actions" to librato.yml. If the option is enabled, librato-rails will instrument ALL actions as if instrument_action was enabled for them.