### PR TITLE
Disable view render instrumentation

### DIFF
--- a/lib/librato/rails/subscribers/render.rb
+++ b/lib/librato/rails/subscribers/render.rb
@@ -1,28 +1,28 @@
-module Librato
-  module Rails
-    module Subscribers
-
-      # Render operations
-
-      %w{partial template}.each do |metric|
-
-        ActiveSupport::Notifications.subscribe "render_#{metric}.action_view" do |*args|
-          event = ActiveSupport::Notifications::Event.new(*args)
-          path = event.payload[:identifier].split('/views/', 2)
-
-          if path[1]
-            source = path[1].gsub('/', ':')
-            # trim leading underscore for partial sources
-            source.gsub!(':_', ':') if metric == 'partial'
-            collector.group "rails.view" do |c|
-              c.increment "render_#{metric}", source: source, sporadic: true
-              c.timing "render_#{metric}.time", event.duration, source: source, sporadic: true
-            end
-          end
-        end
-
-      end
-
-    end
-  end
-end
+# module Librato
+#   module Rails
+#     module Subscribers
+#
+#       # Render operations
+#
+#       %w{partial template}.each do |metric|
+#
+#         ActiveSupport::Notifications.subscribe "render_#{metric}.action_view" do |*args|
+#           event = ActiveSupport::Notifications::Event.new(*args)
+#           path = event.payload[:identifier].split('/views/', 2)
+#
+#           if path[1]
+#             source = path[1].gsub('/', ':')
+#             # trim leading underscore for partial sources
+#             source.gsub!(':_', ':') if metric == 'partial'
+#             collector.group "rails.view" do |c|
+#               c.increment "render_#{metric}", source: source, sporadic: true
+#               c.timing "render_#{metric}.time", event.duration, source: source, sporadic: true
+#             end
+#           end
+#         end
+#
+#       end
+#
+#     end
+#   end
+# end


### PR DESCRIPTION
Temporary branch which disables render instrumentation by hard-coding until https://github.com/librato/librato-rack/pull/39 is available.

For some users with large numbers of controller actions and partials these can add up, so running off this branch is an interim solution.

/cc @gmckeever @jderrett @bdehamer 