### PR TITLE
Define configurable metric suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version X.X.X
+* Add support for configurable metric suites
+
 ### Version 1.2.0
 * Allow use of Rails.application.secrets in the librato.yaml (Zack Siri)
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ else
   rails = "~> #{rails_version}.0"
 end
 
+gem "mime-types", (rails_version >= "4.0" ? "~> 2.9" : "~> 1.16")
 gem "railties", rails
 gem "activesupport", rails
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,48 @@ Note that if a config file is present, _all environment variables will be ignore
 
 For more information on combining config files and environment variables, see the [full configuration docs](https://github.com/librato/librato-rails/wiki/Configuration).
 
+##### Metric Suites
+
+The metrics recorded by `librato-rails` are organized into named metric suites that can be selectively enabled/disabled:
+
+* `rack`: The `rack.request.total`, `rack.request.time`, `rack.request.slow`, and `rack.request.queue.time` metrics
+* `rack_status`: All of the `rack.request.status.*` metrics
+* `rack_method`: All of the `rack.request.method.*` metrics
+* `rails_action`: All of the `rails.action.*` metrics reported by the `instrument_action` helper
+* `rails_cache`: All of the `rails.cache.*` metrics
+* `rails_controller`: The `rails.request.total`, `rails.request.exceptions`, `rails.request.slow` and `rails.request.time.*` metrics
+* `rails_job`: All of the `rails.job.*` metrics
+* `rails_mail`: All of the `rails.mail.*` metrics
+* `rails_method`: All of the `rails.request.method.*` metrics
+* `rails_render`: All of the `rails.view.*` metrics
+* `rails_sql`: All of the `rails.sql.*` metrics
+* `rails_status`: All of the `rails.request.status.*` metrics
+
+All of the metric suites listed above are enabled by default.
+
+The metric suites can be configured via either the `LIBRATO_SUITES` environment variable or the `config/librato.yml` configuration file. The configuration syntax is the same regardless of which configuration method you use.
+
+```bash
+  LIBRATO_SUITES="rails_controller,rails_sql"  # use ONLY the rails_controller and rails_sql suites
+  LIBRATO_SUITES="+foo,+bar"                   # + prefix indicates that you want the default suites plus foo and bar
+  LIBRATO_SUITES="-rails_render"               # - prefix indicates that you want the default suites removing rails_render
+  LIBRATO_SUITES="+foo,-rack_status"           # Use all default suites except for rack_status while also adding foo
+  LIBRATO_SUITES="all"                         # Enable all suites
+  LIBRATO_SUITES="none"                        # Disable all suites
+  LIBRATO_SUITES=""                            # Use only the default suites (same as if env var is absent)
+```
+
+Note that you should EITHER specify an explict list of suites to enable OR add/subtract individual suites from the default list (using the +/- prefixes). If you try to mix these two forms a `Librato::Rack::InvalidSuiteConfiguration` error will be raised.
+
+Configuring the metric suites via the `config/librato.yml` file would look like this:
+
+```yaml
+production:
+  user: name@example.com
+  token: abc123
+  suites: 'all'
+```
+
 ##### Running on Heroku
 
 If you are using the Librato Heroku addon, your user and token environment variables will already be set in your Heroku environment. If you are running without the addon you will need to provide them yourself.

--- a/lib/librato/rails/configuration.rb
+++ b/lib/librato/rails/configuration.rb
@@ -8,7 +8,9 @@ module Librato
     # https://github.com/librato/librato-rack/blob/master/lib/librato/rack/configuration.rb
     #
     class Configuration < Rack::Configuration
-      CONFIG_SETTABLE = %w{user token flush_interval log_level prefix source source_pids proxy}
+      CONFIG_SETTABLE = %w{user token flush_interval log_level prefix source source_pids proxy suites}
+
+      DEFAULT_SUITES = [:rails_action, :rails_cache, :rails_controller, :rails_mail, :rails_method, :rails_render, :rails_sql, :rails_status, :rails_job]
 
       attr_accessor :config_by, :config_file
 
@@ -33,6 +35,7 @@ module Librato
         # respect autorun and log_level env vars regardless of config method
         self.autorun = detect_autorun
         self.log_level = :info if log_level.blank?
+        self.suites = '' if suites.nil?
         self.log_level = ENV['LIBRATO_LOG_LEVEL'] if ENV['LIBRATO_LOG_LEVEL']
       end
 
@@ -45,6 +48,10 @@ module Librato
           settable = CONFIG_SETTABLE & env_specific.keys
           settable.each { |key| self.send("#{key}=", env_specific[key]) }
         end
+      end
+
+      def default_suites
+        super + DEFAULT_SUITES
       end
 
     end

--- a/lib/librato/rails/railtie.rb
+++ b/lib/librato/rails/railtie.rb
@@ -39,6 +39,19 @@ module Librato
           end
         end
 
+        tracker = config.librato_rails.tracker
+        require_relative 'subscribers/action' if tracker.suite_enabled?(:rails_action)
+        require_relative 'subscribers/cache' if tracker.suite_enabled?(:rails_cache)
+        require_relative 'subscribers/controller' if tracker.suite_enabled?(:rails_controller)
+        require_relative 'subscribers/mail' if tracker.suite_enabled?(:rails_mail)
+        require_relative 'subscribers/method' if tracker.suite_enabled?(:rails_method)
+        require_relative 'subscribers/render' if tracker.suite_enabled?(:rails_render)
+        require_relative 'subscribers/sql' if tracker.suite_enabled?(:rails_sql)
+        require_relative 'subscribers/status' if tracker.suite_enabled?(:rails_status)
+
+        Librato::Rails::VersionSpecifier.supported(min: '4.2') do
+          require_relative 'subscribers/job'if tracker.suite_enabled?(:rails_job)
+        end
       end
 
     end

--- a/lib/librato/rails/subscribers.rb
+++ b/lib/librato/rails/subscribers.rb
@@ -11,16 +11,10 @@ module Librato
         @collector ||= Librato.tracker.collector
       end
 
+      def self.watch_controller_action(controller, action)
+        @watches ||= []
+        @watches << "#{controller}##{action}".freeze
+      end
     end
   end
-end
-
-require_relative 'subscribers/cache'
-require_relative 'subscribers/controller'
-require_relative 'subscribers/render'
-require_relative 'subscribers/sql'
-require_relative 'subscribers/mail'
-
-Librato::Rails::VersionSpecifier.supported(min: '4.2') do
-  require_relative 'subscribers/job'
 end

--- a/lib/librato/rails/subscribers/action.rb
+++ b/lib/librato/rails/subscribers/action.rb
@@ -1,0 +1,39 @@
+module Librato
+  module Rails
+    module Subscribers
+
+      # Controller Actions
+
+      ActiveSupport::Notifications.subscribe 'process_action.action_controller' do |*args|
+
+        event = ActiveSupport::Notifications::Event.new(*args)
+        controller = event.payload[:controller]
+        action = event.payload[:action]
+
+        format = event.payload[:format] || "all"
+        format = "all" if format == "*/*"
+        exception = event.payload[:exception]
+
+        if @watches && @watches.index("#{controller}##{action}")
+          source = "#{controller}.#{action}.#{format}"
+          collector.group 'rails.action.request' do |r|
+
+            r.increment 'total', source: source
+            r.increment 'slow', source: source if event.duration > 200.0
+            r.timing    'time', event.duration, source: source, percentile: 95
+
+            if exception
+              r.increment 'exceptions', source: source
+            else
+              r.timing 'time.db', event.payload[:db_runtime] || 0, source: source, percentile: 95
+              r.timing 'time.view', event.payload[:view_runtime] || 0, source: source, percentile: 95
+            end
+
+          end
+        end
+
+      end # end subscribe
+
+    end
+  end
+end

--- a/lib/librato/rails/subscribers/method.rb
+++ b/lib/librato/rails/subscribers/method.rb
@@ -1,0 +1,25 @@
+module Librato
+  module Rails
+    module Subscribers
+
+      # Controller Method
+
+      ActiveSupport::Notifications.subscribe 'process_action.action_controller' do |*args|
+
+        event = ActiveSupport::Notifications::Event.new(*args)
+        http_method = event.payload[:method]
+
+        if http_method
+          verb = http_method.to_s.downcase
+
+          collector.group "rails.request.method" do |m|
+            m.increment verb
+            m.timing "#{verb}.time", event.duration
+          end # end group
+        end
+
+      end # end subscribe
+
+    end
+  end
+end

--- a/lib/librato/rails/subscribers/status.rb
+++ b/lib/librato/rails/subscribers/status.rb
@@ -1,0 +1,25 @@
+module Librato
+  module Rails
+    module Subscribers
+
+      # Controller Status
+
+      ActiveSupport::Notifications.subscribe 'process_action.action_controller' do |*args|
+
+        event = ActiveSupport::Notifications::Event.new(*args)
+        status = event.payload[:status]
+
+        unless status.blank?
+          collector.group "rails.request.status" do |s|
+            s.increment status
+            s.increment "#{status.to_s[0]}xx"
+            s.timing "#{status}.time", event.duration
+            s.timing "#{status.to_s[0]}xx.time", event.duration
+          end # end group
+        end
+
+      end # end subscribe
+
+    end
+  end
+end

--- a/librato-rails.gemspec
+++ b/librato-rails.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "railties", ">= 3.0"
   s.add_dependency "activesupport", ">= 3.0"
-  s.add_dependency "librato-rack", "0.6.0"
+  s.add_dependency "librato-rack", "1.0.0"
 
   s.add_development_dependency "sqlite3", ">= 1.3"
   s.add_development_dependency "capybara", "~> 2.0.3"

--- a/test/fixtures/config/librato.yml
+++ b/test/fixtures/config/librato.yml
@@ -6,6 +6,7 @@ test:
   source: 'custom-1'
   source_pids: false
   proxy: 'http://localhost:8080'
+  suites: all
   
 production:
   user: 'live@bar.com'

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -18,21 +18,12 @@ module Librato
         ENV['LIBRATO_USER'] = 'foo@bar.com'
         ENV['LIBRATO_TOKEN'] = 'api_key'
         ENV['LIBRATO_SOURCE'] = 'source'
+        ENV['LIBRATO_SUITES'] = 'all'
         config = Configuration.new
         assert_equal 'foo@bar.com', config.user
         assert_equal 'api_key', config.token
         assert_equal 'source', config.source
-        assert config.explicit_source?, 'source is explicit'
-      end
-
-      def test_legacy_env_variable_config
-        ENV['LIBRATO_METRICS_USER'] = 'foo@bar.com'
-        ENV['LIBRATO_METRICS_TOKEN'] = 'api_key'
-        ENV['LIBRATO_METRICS_SOURCE'] = 'source'
-        config = Configuration.new
-        assert_equal 'foo@bar.com', config.user
-        assert_equal 'api_key', config.token
-        assert_equal 'source', config.source
+        assert_equal 'all', config.suites
         assert config.explicit_source?, 'source is explicit'
       end
 
@@ -45,6 +36,7 @@ module Librato
         assert_equal 'custom-1', config.source
         assert_equal false, config.source_pids
         assert_equal 'http://localhost:8080', config.proxy
+        assert_equal 'all', config.suites
         assert config.explicit_source?, 'source is explicit'
       end
 
@@ -69,6 +61,26 @@ module Librato
       def test_empty_config_file_doesnt_break_log_level
         config = fixture_config('empty')
         assert_equal :info, config.log_level, 'should be default'
+      end
+
+      def test_empty_config_file_doesnt_break_suites
+        config = fixture_config('empty')
+        assert_equal '', config.suites, 'should be default'
+      end
+
+      def test_default_suites
+        defaults = Configuration.new.send(:default_suites)
+        assert_includes defaults, :rack
+        assert_includes defaults, :rack_method
+        assert_includes defaults, :rack_status
+        assert_includes defaults, :rails_cache
+        assert_includes defaults, :rails_controller
+        assert_includes defaults, :rails_mail
+        assert_includes defaults, :rails_method
+        assert_includes defaults, :rails_render
+        assert_includes defaults, :rails_sql
+        assert_includes defaults, :rails_status
+        assert_includes defaults, :rails_job
       end
 
       def fixture_config(file='librato')


### PR DESCRIPTION
Allows users to selectively enable/disable different suites of metrics.

The suites are organized around the different ActiveSupport Instrumentation events which are used to collect the metrics:

* `rails_cache`: The `rails.cache.*` metrics.
* `rails_controller`: The `rails.request.*` metrics
* `rails_render`: The `rails.view.*` metrics
* `rails_sql`: The `rails.sql.*` metrics
* `rails_mail`: The `rails.mail.*` metrics
* `rails_job`: The `rails.job.*` metrics

Metric suites can be configured either via the `LIBRATO_SUITES` environment variable

```bash
LIBRATO_SUITES="-rails_view"
```

or via the `librato.yml` configuration file:

```yaml
production:
  suites: "-rails_view"
```

Dependent on https://github.com/librato/librato-rack/pull/39 