### PR TITLE
Bump librato-rack dependency to 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Version X.X.X
+* Bump librato-rack dependency to fix missing p95 for rack.request.time
+* Loosen librato-rack dependency to any 1.0.x versions
+
 ### Version 1.4.0
 * Add support to instrument all controller actions, e.g., `instrument_action :all`.
 

--- a/librato-rails.gemspec
+++ b/librato-rails.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "railties", ">= 3.0"
   s.add_dependency "activesupport", ">= 3.0"
-  s.add_dependency "librato-rack", "1.0.0"
+  s.add_dependency "librato-rack", "~> 1.0.1"
 
   s.add_development_dependency "sqlite3", ">= 1.3"
   s.add_development_dependency "capybara", "~> 2.0.3"


### PR DESCRIPTION
Make sure that any `librato-rails` users get the latest version of `librato-rack` with the rack.request.time p95 fix.

https://github.com/librato/librato-rack/pull/52