### PR TITLE
Bump librato-rack to latest for Ruby 2.4 fixes

### DIFF
--- a/librato-rails.gemspec
+++ b/librato-rails.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "railties", ">= 3.0"
   s.add_dependency "activesupport", ">= 3.0"
-  s.add_dependency "librato-rack", "~> 1.0.1"
+  s.add_dependency "librato-rack", "~> 1.1.0"
 
   s.add_development_dependency "sqlite3", ">= 1.3"
   s.add_development_dependency "capybara", "~> 2.0.3"


### PR DESCRIPTION
Fixes #127, part of #128 