### PR TITLE
Inherit Tags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'benchmark_suite'
 # https://github.com/librato/librato-rack/pull/54
 gem 'librato-rack',
   git: 'https://github.com/librato/librato-rack.git',
-  branch: 'feature/md'
+  branch: 'feature/inherit-tags'
 
 # platforms :rbx do
 #   gem 'rubysl', '~> 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'benchmark_suite'
 # https://github.com/librato/librato-rack/pull/54
 gem 'librato-rack',
   git: 'https://github.com/librato/librato-rack.git',
-  branch: 'feature/inherit-tags'
+  branch: 'feature/md'
 
 # platforms :rbx do
 #   gem 'rubysl', '~> 2.0'

--- a/lib/librato/rails/subscribers/controller.rb
+++ b/lib/librato/rails/subscribers/controller.rb
@@ -17,13 +17,13 @@ module Librato
         }
 
         collector.group "rails.request" do |r|
-          r.increment "total", tags: tags
-          r.timing    "time", event.duration, tags: tags, percentile: 95
-          r.timing "time.db", event.payload[:db_runtime] || 0, tags: tags, percentile: 95
-          r.timing "time.view", event.payload[:view_runtime] || 0, tags: tags, percentile: 95
+          r.increment "total", tags: tags, inherit_tags: true
+          r.timing    "time", event.duration, tags: tags, inherit_tags: true, percentile: 95
+          r.timing "time.db", event.payload[:db_runtime] || 0, tags: tags, inherit_tags: true, percentile: 95
+          r.timing "time.view", event.payload[:view_runtime] || 0, tags: tags, inherit_tags: true, percentile: 95
 
           if event.duration > 200.0
-            r.increment "slow", tags: tags
+            r.increment "slow", tags: tags, inherit_tags: true
           end
         end # end group
 

--- a/lib/librato/rails/subscribers/job.rb
+++ b/lib/librato/rails/subscribers/job.rb
@@ -15,8 +15,8 @@ module Librato
           }
 
           collector.group "rails.job" do |c|
-            c.increment metric, tags: tags
-            c.timing "#{metric}.time", event.duration, tags: tags
+            c.increment metric, tags: tags, inherit_tags: true
+            c.timing "#{metric}.time", event.duration, tags: tags, inherit_tags: true
           end # end group
 
         end # end subscribe

--- a/lib/librato/rails/subscribers/mail.rb
+++ b/lib/librato/rails/subscribers/mail.rb
@@ -7,13 +7,13 @@ module Librato
       ActiveSupport::Notifications.subscribe "deliver.action_mailer" do |*args|
         event = ActiveSupport::Notifications::Event.new(*args)
         tags = { mailer: event.payload[:mailer] }
-        collector.increment "rails.mail.sent", tags: tags
+        collector.increment "rails.mail.sent", tags: tags, inherit_tags: true
       end # end subscribe
 
       ActiveSupport::Notifications.subscribe "receive.action_mailer" do |*args|
         event = ActiveSupport::Notifications::Event.new(*args)
         tags = { mailer: event.payload[:mailer] }
-        collector.increment "rails.mail.received", tags: tags
+        collector.increment "rails.mail.received", tags: tags, inherit_tags: true
       end # end subscribe
 
     end

--- a/lib/librato/rails/subscribers/method.rb
+++ b/lib/librato/rails/subscribers/method.rb
@@ -11,8 +11,8 @@ module Librato
 
         if tags[:method]
           collector.group "rails.request" do |m|
-            m.increment "method", tags: tags
-            m.timing "method.time", event.duration, tags: tags
+            m.increment "method", tags: tags, inherit_tags: true
+            m.timing "method.time", event.duration, tags: tags, inherit_tags: true
           end # end group
         end
 

--- a/lib/librato/rails/subscribers/render.rb
+++ b/lib/librato/rails/subscribers/render.rb
@@ -10,15 +10,16 @@ module Librato
 
           event = ActiveSupport::Notifications::Event.new(*args)
           path = event.payload[:identifier].split('/views/', 2)
+          metric = metric.to_sym
 
           if path[1]
             identifier = path[1].gsub('/', ':')
             # trim leading underscore for partials
-            identifier.gsub!(':_', ':') if metric == "partial"
+            identifier.gsub!(':_', ':') if metric == :partial
             tags = { metric => identifier }
             collector.group "rails.view.render" do |c|
-              c.increment metric, tags: tags, sporadic: true
-              c.timing "#{metric}.time", event.duration, tags: tags, sporadic: true
+              c.increment metric, tags: tags, inherit_tags: true, sporadic: true
+              c.timing "#{metric}.time", event.duration, tags: tags, inherit_tags: true, sporadic: true
             end # end group
           end
 

--- a/lib/librato/rails/subscribers/status.rb
+++ b/lib/librato/rails/subscribers/status.rb
@@ -11,8 +11,8 @@ module Librato
 
         unless tags[:status].blank?
           collector.group "rails.request" do |s|
-            s.increment "status", tags: tags
-            s.timing "status.time", event.duration, tags: tags
+            s.increment "status", tags: tags, inherit_tags: true
+            s.timing "status.time", event.duration, tags: tags, inherit_tags: true
           end # end group
         end
 

--- a/test/integration/instrument_action_test.rb
+++ b/test/integration/instrument_action_test.rb
@@ -7,7 +7,7 @@ class InstrumentActionTest < ActiveSupport::IntegrationCase
       controller: "InstrumentActionController",
       action: "inst",
       format: "html"
-    }
+    }.merge(default_tags)
 
     visit instrument_action_path
 
@@ -31,13 +31,13 @@ class InstrumentActionTest < ActiveSupport::IntegrationCase
         controller: "BaseController",
         action: "action_1",
         format: "html"
-      })[:count]
+      }.merge(default_tags))[:count]
     assert_equal 1, aggregate.fetch(metric,
       tags: {
         controller: "BaseController",
         action: "action_2",
         format: "html"
-      })[:count]
+      }.merge(default_tags))[:count]
   end
 
   test "instrument all controller actions for inherited controllers" do
@@ -52,19 +52,19 @@ class InstrumentActionTest < ActiveSupport::IntegrationCase
         controller: "IntermediateController",
         action: "action_1",
         format: "html"
-      })[:count]
+      }.merge(default_tags))[:count]
     assert_equal 1, aggregate.fetch(metric,
       tags: {
         controller: "DerivedController",
         action: "action_1",
         format: "html"
-      })[:count]
+      }.merge(default_tags))[:count]
     assert_equal 1, aggregate.fetch(metric,
       tags: {
         controller: "DerivedController",
         action: "action_2",
         format: "html"
-      })[:count]
+      }.merge(default_tags))[:count]
   end
 
   test "instrument all controller actions for all controllers" do
@@ -77,7 +77,7 @@ class InstrumentActionTest < ActiveSupport::IntegrationCase
         controller: "InstrumentActionController",
         action: "not",
         format: "html"
-      })[:count]
+      }.merge(default_tags))[:count]
   end
 
   test "instrument invalid format" do
@@ -92,7 +92,7 @@ class InstrumentActionTest < ActiveSupport::IntegrationCase
         controller: "InstrumentActionController",
         action: "invalid_format",
         format: "all"
-      })[:count]
+      }.merge(default_tags))[:count]
 
     Capybara.current_session.driver.header "Accept", nil
   end

--- a/test/integration/job_test.rb
+++ b/test/integration/job_test.rb
@@ -6,7 +6,7 @@ class JobTest < ActiveSupport::IntegrationCase
       tags = {
         adapter: "inline_adapter",
         job: "dummy_job"
-      }
+      }.merge(default_tags)
 
       DummyJob.perform_now
 
@@ -18,7 +18,7 @@ class JobTest < ActiveSupport::IntegrationCase
       tags = {
         adapter: "inline_adapter",
         job: "dummy_job"
-      }
+      }.merge(default_tags)
 
       DummyJob.perform_later
 

--- a/test/integration/mail_test.rb
+++ b/test/integration/mail_test.rb
@@ -4,14 +4,16 @@ class MailTest < ActiveSupport::IntegrationCase
 
   test 'mail sent' do
     user = User.create!(:email => 'foo@foo.com', :password => 'wow')
+    tags = { mailer: "UserMailer" }.merge(default_tags)
     UserMailer.welcome_email(user).deliver
-    assert_equal 1, counters.fetch("rails.mail.sent", tags: { mailer: "UserMailer" })[:value]
+    assert_equal 1, counters.fetch("rails.mail.sent", tags: tags)[:value]
   end
 
   test "mail received" do
     user = User.create!(email: "foo@foo.com", password: "foobar")
+    tags = { mailer: "UserMailer" }.merge(default_tags)
     UserMailer.receive(user.email)
-    assert_equal 1, counters.fetch("rails.mail.received", tags: { mailer: "UserMailer" })[:value]
+    assert_equal 1, counters.fetch("rails.mail.received", tags: tags)[:value]
   end
 
 end

--- a/test/integration/render_test.rb
+++ b/test/integration/render_test.rb
@@ -6,22 +6,22 @@ class RenderTest < ActiveSupport::IntegrationCase
     visit render_partial_path
 
     assert_equal 1, counters.fetch("rails.view.render.partial",
-                                      tags: { 'partial' => "render:first.html.erb" })[:value]
+                                      tags: { partial: "render:first.html.erb" }.merge(default_tags))[:value]
     assert_equal 1, counters.fetch("rails.view.render.partial",
-                                      tags: { 'partial' => "render:second.html.erb" })[:value]
+                                      tags: { partial: "render:second.html.erb" }.merge(default_tags))[:value]
     assert_equal 1, aggregate.fetch("rails.view.render.partial.time",
-                                      tags: { 'partial' => "render:first.html.erb" })[:count]
+                                      tags: { partial: "render:first.html.erb" }.merge(default_tags))[:count]
     assert_equal 1, aggregate.fetch("rails.view.render.partial.time",
-                                      tags: { 'partial' => "render:second.html.erb" })[:count]
+                                      tags: { partial: "render:second.html.erb" }.merge(default_tags))[:count]
   end
 
   test 'render template' do
     visit render_template_path
 
     assert_equal 1, counters.fetch("rails.view.render.template",
-                                      tags: { 'template' => "render:template.html.erb" })[:value]
+                                      tags: { template: "render:template.html.erb" }.merge(default_tags))[:value]
     assert_equal 1, aggregate.fetch("rails.view.render.template.time",
-                                      tags: { 'template' => "render:template.html.erb" })[:count]
+                                      tags: { template: "render:template.html.erb" }.merge(default_tags))[:count]
   end
 
 end

--- a/test/integration/request_test.rb
+++ b/test/integration/request_test.rb
@@ -9,7 +9,7 @@ class RequestTest < ActiveSupport::IntegrationCase
       controller: "HomeController",
       action: "index",
       format: "html"
-    }
+    }.merge(default_tags)
 
     visit root_path
 
@@ -25,7 +25,7 @@ class RequestTest < ActiveSupport::IntegrationCase
       controller: "StatusController",
       action: "index",
       format: "html"
-    }
+    }.merge(default_tags)
 
     visit '/status/204'
 
@@ -38,7 +38,7 @@ class RequestTest < ActiveSupport::IntegrationCase
       controller: "HomeController",
       action: "index",
       format: "html"
-    }
+    }.merge(default_tags)
 
     visit root_path
 
@@ -62,7 +62,7 @@ class RequestTest < ActiveSupport::IntegrationCase
       controller: "HomeController",
       action: "slow",
       format: "html"
-    }
+    }.merge(default_tags)
 
     visit slow_path
     assert_equal 1, counters.fetch("rails.request.slow", tags: tags)[:value]

--- a/test/integration/request_test.rb
+++ b/test/integration/request_test.rb
@@ -14,7 +14,7 @@ class RequestTest < ActiveSupport::IntegrationCase
     visit root_path
 
     assert_equal 1, counters.fetch("rails.request.total", tags: tags_1)[:value]
-    assert_equal 1, counters.fetch("rails.request.status", tags: { status: 200 })[:value]
+    assert_equal 1, counters.fetch("rails.request.status", tags: { status: 200 }.merge(default_tags))[:value]
     assert_equal 1, counters.fetch("rails.request.method", tags: { method: "get" })[:value]
 
     visit root_path
@@ -30,7 +30,7 @@ class RequestTest < ActiveSupport::IntegrationCase
     visit '/status/204'
 
     assert_equal 1, counters.fetch("rails.request.total", tags: tags_2)[:value]
-    assert_equal 1, counters.fetch("rails.request.status", tags: { status: 204 })[:value]
+    assert_equal 1, counters.fetch("rails.request.status", tags: { status: 204 }.merge(default_tags))[:value]
   end
 
   test 'request times' do
@@ -51,7 +51,7 @@ class RequestTest < ActiveSupport::IntegrationCase
       'should record view time'
 
     # status specific
-    assert_equal 1, aggregate.fetch("rails.request.status.time", tags: { status: 200 })[:count]
+    assert_equal 1, aggregate.fetch("rails.request.status.time", tags: { status: 200 }.merge(default_tags))[:count]
 
     # http method specific
     assert_equal 1, aggregate.fetch("rails.request.method.time", tags: { method: "get" })[:count]

--- a/test/integration/request_test.rb
+++ b/test/integration/request_test.rb
@@ -15,7 +15,7 @@ class RequestTest < ActiveSupport::IntegrationCase
 
     assert_equal 1, counters.fetch("rails.request.total", tags: tags_1)[:value]
     assert_equal 1, counters.fetch("rails.request.status", tags: { status: 200 }.merge(default_tags))[:value]
-    assert_equal 1, counters.fetch("rails.request.method", tags: { method: "get" })[:value]
+    assert_equal 1, counters.fetch("rails.request.method", tags: { method: "get" }.merge(default_tags))[:value]
 
     visit root_path
 
@@ -54,7 +54,7 @@ class RequestTest < ActiveSupport::IntegrationCase
     assert_equal 1, aggregate.fetch("rails.request.status.time", tags: { status: 200 }.merge(default_tags))[:count]
 
     # http method specific
-    assert_equal 1, aggregate.fetch("rails.request.method.time", tags: { method: "get" })[:count]
+    assert_equal 1, aggregate.fetch("rails.request.method.time", tags: { method: "get" }.merge(default_tags))[:count]
   end
 
   test 'track slow requests' do

--- a/test/support/integration_case.rb
+++ b/test/support/integration_case.rb
@@ -20,4 +20,8 @@ class ActiveSupport::IntegrationCase < ActiveSupport::TestCase
   def counters
     collector.counters
   end
+
+  def default_tags
+    collector.tags
+  end
 end


### PR DESCRIPTION
Use `:inherit_tags` option introduced in https://github.com/librato/librato-rack/pull/65 to inherit default tags (`service`, `environment`,`host`) for automatic instrumentation.

Tag inheritance is also applicable to custom instrumentation. Here’s a few examples:

```ruby
Librato.increment 'user.signup'
# => {:host=>"ip-10-0-0-4.ec2.internal"}

Librato.increment 'user.signup', tags: { plan: 'developer' }
#=> {:plan=>"developer"}

Librato.increment 'user.signup', tags: { plan: 'developer' }, inherit_tags: true
# => {:host=>"ip-10-0-0-4.ec2.internal", :plan=>"developer"}
```

Merge into https://github.com/librato/librato-rails/pull/123. Requires https://github.com/librato/librato-rack/pull/65.