### PR TITLE
Rails 5.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - 2.1.10
   - 2.2.6
   - 2.3.3
-  # - 2.4.0
+  - 2.4.0
   # - jruby-19mode
   # - jruby-18mode
   # - rbx
@@ -18,6 +18,7 @@ env:
   - "RAILS_VERSION=4.0"
   - "RAILS_VERSION=4.1"
   - "RAILS_VERSION=4.2"
+  - "RAILS_VERSION=5.0"
 
 matrix:
   exclude:
@@ -35,8 +36,17 @@ matrix:
       env: "RAILS_VERSION=3.2"
     - rvm: 1.9.3
       env: "RAILS_VERSION=4.0"
+    - rvm: 2.4.0
+      env: "RAILS_VERSION=4.0"
     - rvm: 1.9.3
+      env: "RAILS_VERSION=4.1"
+    - rvm: 2.4.0
       env: "RAILS_VERSION=4.1"
     - rvm: 1.9.3
       env: "RAILS_VERSION=4.2"
-
+    - rvm: 2.4.0
+      env: "RAILS_VERSION=4.2"
+    - rvm: 1.9.3
+      env: "RAILS_VERSION=5.0"
+    - rvm: 2.1.10
+      env: "RAILS_VERSION=5.0"

--- a/lib/librato/rails/subscribers/job.rb
+++ b/lib/librato/rails/subscribers/job.rb
@@ -9,10 +9,16 @@ module Librato
         ActiveSupport::Notifications.subscribe "#{metric}.active_job" do |*args|
 
           event = ActiveSupport::Notifications::Event.new(*args)
+
           tags = {
-            adapter: event.payload[:adapter].to_s.demodulize.underscore,
+            adapter: event.payload[:adapter].class.to_s.demodulize.underscore,
             job: event.payload[:job].class.to_s.demodulize.underscore
           }
+
+          Librato::Rails::VersionSpecifier.supported(max: '4.2') do
+            # :adapter is already a class in 4.2
+            tags[:adapter] = event.payload[:adapter].to_s.demodulize.underscore
+          end
 
           collector.group "rails.job" do |c|
             c.increment metric, tags: tags, inherit_tags: true

--- a/lib/librato/rails/subscribers/job.rb
+++ b/lib/librato/rails/subscribers/job.rb
@@ -15,7 +15,7 @@ module Librato
             job: event.payload[:job].class.to_s.demodulize.underscore
           }
 
-          Librato::Rails::VersionSpecifier.supported(max: '4.2') do
+          VersionSpecifier.supported(max: '4.2') do
             # :adapter is already a class in 4.2
             tags[:adapter] = event.payload[:adapter].to_s.demodulize.underscore
           end

--- a/lib/librato/rails/subscribers/job.rb
+++ b/lib/librato/rails/subscribers/job.rb
@@ -2,7 +2,7 @@ module Librato
   module Rails
     module Subscribers
 
-      # ActionJob
+      # Active Job
 
       %w{enqueue_at enqueue perform_start perform}.each do |metric|
 
@@ -16,7 +16,8 @@ module Librato
           }
 
           VersionSpecifier.supported(max: '4.2') do
-            # :adapter is already a class in 4.2
+            # Active Support instrumentation payload for :adapter is already a class in Rails 4.2.
+            # It was changed to the QueueAdapter object processing the job in Rails 5.
             tags[:adapter] = event.payload[:adapter].to_s.demodulize.underscore
           end
 

--- a/test/dummy/app/controllers/cache_controller.rb
+++ b/test/dummy/app/controllers/cache_controller.rb
@@ -1,5 +1,9 @@
 class CacheController < ApplicationController
-  Librato::Rails::VersionSpecifier.supported(max: '4.1') { before_filter :instrument_caching }
+  Librato::Rails::VersionSpecifier.supported(max: '4.1') do
+    # ActiveSupport::Cache.instrument= was removed in Rails 5.
+    # Instrumentation is now always on so you can safely stop using it.
+    before_filter :instrument_caching
+  end
   after_filter  :clear_cache
 
   def read

--- a/test/dummy/app/controllers/cache_controller.rb
+++ b/test/dummy/app/controllers/cache_controller.rb
@@ -1,5 +1,5 @@
 class CacheController < ApplicationController
-  before_filter :instrument_caching
+  Librato::Rails::VersionSpecifier.supported(max: '4.1') { before_filter :instrument_caching }
   after_filter  :clear_cache
 
   def read

--- a/test/dummy/app/controllers/cache_controller.rb
+++ b/test/dummy/app/controllers/cache_controller.rb
@@ -1,6 +1,6 @@
 class CacheController < ApplicationController
   Librato::Rails::VersionSpecifier.supported(max: '4.1') do
-    # ActiveSupport::Cache.instrument= was removed in Rails 5.
+    # ActiveSupport::Cache.instrument= was deprecated in Rails 4.2.
     # Instrumentation is now always on so you can safely stop using it.
     before_filter :instrument_caching
   end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -63,5 +63,10 @@ module Dummy
     # set librato_rails prefix
     # config.librato_rails.prefix = 'dummy'
     config.librato_rails.flush_interval = 5
+
+    Librato::Rails::VersionSpecifier.supported(min: '5.0') do
+      # https://github.com/rails/rails/commit/625baa69d14881ac49ba2e5c7d9cac4b222d7022
+      config.active_job.queue_adapter = :inline
+    end
   end
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -65,7 +65,8 @@ module Dummy
     config.librato_rails.flush_interval = 5
 
     Librato::Rails::VersionSpecifier.supported(min: '5.0') do
-      # https://github.com/rails/rails/commit/625baa69d14881ac49ba2e5c7d9cac4b222d7022
+      # Default behavior for queue adapter was changed from :inline to :async in Rails 5.
+      # This encourages using a persistent queuing backend in production. In-process queuing will suffice for tests.
       config.active_job.queue_adapter = :inline
     end
   end

--- a/test/integration/job_test.rb
+++ b/test/integration/job_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+Librato::Rails::VersionSpecifier.supported(min: '4.2') { require 'dummy_job' }
 
 class JobTest < ActiveSupport::IntegrationCase
   Librato::Rails::VersionSpecifier.supported(min: '4.2') do

--- a/test/integration/job_test.rb
+++ b/test/integration/job_test.rb
@@ -1,5 +1,8 @@
 require 'test_helper'
-Librato::Rails::VersionSpecifier.supported(min: '4.2') { require 'dummy_job' }
+Librato::Rails::VersionSpecifier.supported(min: '4.2') do
+  # Active Job framework was introduced in Rails 4.2.
+  require 'dummy_job'
+end
 
 class JobTest < ActiveSupport::IntegrationCase
   Librato::Rails::VersionSpecifier.supported(min: '4.2') do


### PR DESCRIPTION
Add support for Rails 5.0. Introduce the following changes:

- Add Ruby 2.4 to build matrix for Rails 5 only
- Use `VersionSpecifier` to ensure CI passes for all supported Rails versions
- Update job subscriber to use `QueueAdapter` class as tag value in Rails >= 5.0

Active Support instrumentation API changed the default event payload value to `QueueAdapter` object processing the job in Rails 5.0, the event payload was already a class in Rails 4.2.