### PR TITLE
Deprecate .exists? method

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ end
 
 task 'before_build' do
   signing_key = File.expand_path("~/.gem/librato-private_key.pem")
-  if File.exists?(signing_key)
+  if File.exist?(signing_key)
     puts "Key found: signing gem..."
     ENV['GEM_SIGNING_KEY'] = signing_key
   else

--- a/lib/librato/rails/configuration.rb
+++ b/lib/librato/rails/configuration.rb
@@ -25,7 +25,7 @@ module Librato
 
       # detect and load configuration from config file or env vars
       def load_configuration
-        if self.config_file && File.exists?(self.config_file)
+        if self.config_file && File.exist?(self.config_file)
           configure_with_config_file
         else
           self.config_by = :environment


### PR DESCRIPTION
Context:
```
NoMethodError: undefined method `exists?' for File:Class
/home/circleci/project/vendor/bundle/ruby/3.2.0/gems/librato-rails-1.4.2/lib/librato/rails/configuration.rb:28:in `load_configuration'
/home/circleci/project/vendor/bundle/ruby/3.2.0/bundler/gems/librato-rack-506b9b0f70b8/lib/librato/rack/configuration.rb:34:in `initialize'
/home/circleci/project/vendor/bundle/ruby/3.2.0/gems/librato-rails-1.4.2/lib/librato/rails/configuration.rb:22:in `initialize'
```